### PR TITLE
Updating Guava dependency from 16.x to 21.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.codepine.api</groupId>
     <artifactId>testrail-api-java-client</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>TestRail API Java Client</name>
@@ -46,7 +46,7 @@
         <jdk.version>1.7</jdk.version>
         <lombok.version>1.16.2</lombok.version>
         <jackson.version>2.3.1</jackson.version>
-        <guava.version>16.0.1</guava.version>
+        <guava.version>21.0</guava.version>
         <log4j.version>1.2.17</log4j.version>
         <junit.version>4.11</junit.version>
         <mockito.version>1.9.5</mockito.version>

--- a/src/main/java/com/codepine/api/testrail/model/Case.java
+++ b/src/main/java/com/codepine/api/testrail/model/Case.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.StdKeySerializer;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import lombok.Data;
 
 import java.io.IOException;
@@ -95,7 +95,7 @@ public class Case {
     @JsonAnyGetter
     @JsonSerialize(keyUsing = CustomFieldSerializer.class)
     public Map<String, Object> getCustomFields() {
-        return Objects.firstNonNull(customFields, Collections.<String, Object>emptyMap());
+        return MoreObjects.firstNonNull(customFields, Collections.<String, Object>emptyMap());
     }
 
     /**

--- a/src/main/java/com/codepine/api/testrail/model/Result.java
+++ b/src/main/java/com/codepine/api/testrail/model/Result.java
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.StdKeySerializer;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -119,7 +119,7 @@ public class Result {
     @JsonAnyGetter
     @JsonSerialize(keyUsing = CustomFieldSerializer.class)
     public Map<String, Object> getCustomFields() {
-        return Objects.firstNonNull(customFields, Collections.<String, Object>emptyMap());
+        return MoreObjects.firstNonNull(customFields, Collections.<String, Object>emptyMap());
     }
 
     /**

--- a/src/main/java/com/codepine/api/testrail/model/Test.java
+++ b/src/main/java/com/codepine/api/testrail/model/Test.java
@@ -25,7 +25,7 @@
 package com.codepine.api.testrail.model;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import lombok.Data;
 
 import java.util.Collections;
@@ -67,7 +67,7 @@ public class Test {
     private Map<String, Object> customFields;
 
     public Map<String, Object> getCustomFields() {
-        return Objects.firstNonNull(customFields, Collections.<String, Object>emptyMap());
+        return MoreObjects.firstNonNull(customFields, Collections.<String, Object>emptyMap());
     }
 
     /**


### PR DESCRIPTION
All 40 tests passed; installed locally and ran with project and report was successfully generated with a backing Guava dependency of 21