### PR TITLE
Add support to Report

### DIFF
--- a/src/main/java/com/codepine/api/testrail/TestRail.java
+++ b/src/main/java/com/codepine/api/testrail/TestRail.java
@@ -34,6 +34,7 @@ import com.codepine.api.testrail.model.Milestone;
 import com.codepine.api.testrail.model.Plan;
 import com.codepine.api.testrail.model.Priority;
 import com.codepine.api.testrail.model.Project;
+import com.codepine.api.testrail.model.ReportLinks;
 import com.codepine.api.testrail.model.Result;
 import com.codepine.api.testrail.model.ResultField;
 import com.codepine.api.testrail.model.Run;
@@ -1449,7 +1450,6 @@ public class TestRail {
 
     }
 
-
     /**
      * Request factories for "Result Fields".
      */
@@ -2070,5 +2070,53 @@ public class TestRail {
             }
         }
 
+    }
+
+    /**
+     * Request factories for "Report".
+     */
+    @NoArgsConstructor
+    public class Report {
+
+        /**
+         * Returns an existing report links.
+         *
+         * @param reportId the ID of the report
+         * @return the request
+         * @throws java.lang.IllegalArgumentException if reportId is not positive
+         */
+        public Get get(final int reportId) {
+            checkArgument(reportId > 0, "reportId should be positive");
+            return new Get(reportId);
+        }
+
+        /**
+         * Returns a list of reports for a project.
+         *
+         * @param projectId the ID of the project to get the reports for
+         * @return the request
+         * @throws java.lang.IllegalArgumentException if projectId is not positive
+         */
+        public List list(final int projectId) {
+            checkArgument(projectId > 0, "projectId should be positive");
+            return new List(projectId);
+        }
+
+        public class Get extends Request<ReportLinks> {
+            private static final String REST_PATH = "run_report/";
+
+            private Get(int reportId) {
+                super(config, Method.GET, REST_PATH + reportId, ReportLinks.class);
+            }
+        }
+
+        public class List extends Request<java.util.List<com.codepine.api.testrail.model.Report>> {
+            private static final String REST_PATH = "get_reports/";
+
+            private List(int projectId) {
+                super(config, Method.GET, REST_PATH + projectId, new TypeReference<java.util.List<com.codepine.api.testrail.model.Report>>() {
+                });
+            }
+        }
     }
 }

--- a/src/main/java/com/codepine/api/testrail/model/Report.java
+++ b/src/main/java/com/codepine/api/testrail/model/Report.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Kunal Shah
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.codepine.api.testrail.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.Getter;
+
+import java.io.IOException;
+
+/**
+ * TestRail report.
+ */
+@Data
+public class Report {
+    private boolean statusInclude;
+
+    private String activitiesDaterangeFrom;
+
+    @JsonProperty
+    @Getter(onMethod = @_({@JsonIgnore}))
+    private boolean contentHideLinks;
+
+    @JsonProperty
+    @Getter(onMethod = @_({@JsonIgnore}))
+    private boolean progressInclude;
+
+    @JsonProperty
+    @Getter(onMethod = @_({@JsonIgnore}))
+    private boolean testsInclude;
+
+    private String activitiesDaterange;
+
+    private String description;
+
+    private String activitiesStatusesInclude;
+
+    private String runsFilters;
+
+    private String testsFilters;
+
+    private String activitiesStatusesIds;
+
+    private int activitiesLimit;
+
+    @JsonProperty
+    @Getter(onMethod = @_({@JsonIgnore}))
+    private boolean notifyAttachmentHtmlFormat;
+
+    private int testsLimit;
+
+    private String runsSuitesIds;
+
+    private int id;
+
+    private TestsColumns testsColumns;
+
+    private String notifyLinkRecipients;
+
+    @JsonProperty
+    @Getter(onMethod = @_({@JsonIgnore}))
+    private boolean notifyUser;
+
+    private String activitiesDaterangeTo;
+
+    private int runsLimit;
+
+    @JsonProperty
+    @Getter(onMethod = @_({@JsonIgnore}))
+    private boolean notifyLink;
+
+    private String notifyAttachmentRecipients;
+
+    @JsonProperty
+    @Getter(onMethod = @_({@JsonIgnore}))
+    private boolean notifyAttachmentPdfFormat;
+
+    private java.util.List<Integer> runsIds;
+
+    private String runsSuitesInclude;
+
+    @JsonProperty
+    @Getter(onMethod = @_({@JsonIgnore}))
+    private boolean activitiesInclude;
+
+    private String runsInclude;
+
+    private String name;
+
+    @Data
+    public static class TestsColumns{
+
+        @JsonProperty("cases:title")
+        private int casesTitle;
+
+        @JsonProperty("tests:id")
+        private int testsId;
+    }
+}

--- a/src/main/java/com/codepine/api/testrail/model/ReportLinks.java
+++ b/src/main/java/com/codepine/api/testrail/model/ReportLinks.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Kunal Shah
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.codepine.api.testrail.model;
+
+import lombok.Data;
+
+/**
+ * TestRail report links.
+ */
+@Data
+public class ReportLinks {
+
+    private String reportUrl;
+
+    private String reportHtml;
+
+    private String reportPdf;
+}


### PR DESCRIPTION
## What
Add support to Report.

## How
We need to create two response models:
- `Report`
- `ReportLinks`

Then, we need to add these two requests in `TestRail` api:
- `run_report/$reportId`
- `get_reports/$projectId`

More info here: http://docs.gurock.com/testrail-api2/reference-reports

As you can notice, `Report` model is kind of different from documentation. It seems the documentation is outdated. 🤷‍♂️ 

## Screenshot
### Build success
![image](https://user-images.githubusercontent.com/1906734/84401574-b896ee80-ac03-11ea-9e7e-9ab8e9347e6b.png)

### Tested the jar
![image](https://user-images.githubusercontent.com/1906734/84402073-4d015100-ac04-11ea-8a4d-bb7ab5b435c0.png)

