### PR TITLE
Add sectionId update support

### DIFF
--- a/src/main/java/com/codepine/api/testrail/model/Case.java
+++ b/src/main/java/com/codepine/api/testrail/model/Case.java
@@ -59,6 +59,7 @@ public class Case {
     @JsonView({TestRail.Cases.Add.class, TestRail.Cases.Update.class})
     private String title;
 
+    @JsonView(TestRail.Cases.Update.class)
     private int sectionId;
 
     @JsonView({TestRail.Cases.Add.class, TestRail.Cases.Update.class})


### PR DESCRIPTION
Support updating case's section id. Since TestRail supported updating `section_id` since version 6.5.2, this support in this java client is still lacking. So here is to add this support.