### PR TITLE
Replace deprecated naming strategy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <!-- dependencies -->
         <jdk.version>1.8</jdk.version>
         <lombok.version>1.16.2</lombok.version>
-        <jackson.version>2.13.4</jackson.version>
+        <jackson.version>2.20.0</jackson.version>
         <guava.version>21.0</guava.version>
         <log4j.version>1.2.17</log4j.version>
         <junit.version>4.11</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.codepine.api</groupId>
     <artifactId>testrail-api-java-client</artifactId>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.0.3-replace-deprecated-naming-strategy</version>
     <packaging>jar</packaging>
 
     <name>TestRail API Java Client</name>
@@ -45,7 +45,7 @@
         <!-- dependencies -->
         <jdk.version>1.8</jdk.version>
         <lombok.version>1.16.2</lombok.version>
-        <jackson.version>2.3.1</jackson.version>
+        <jackson.version>2.13.4</jackson.version>
         <guava.version>21.0</guava.version>
         <log4j.version>1.2.17</log4j.version>
         <junit.version>4.11</junit.version>

--- a/src/main/java/com/codepine/api/testrail/Request.java
+++ b/src/main/java/com/codepine/api/testrail/Request.java
@@ -55,7 +55,7 @@ public abstract class Request<T> {
     private static final UrlConnectionFactory DEFAULT_URL_CONNECTION_FACTORY = new UrlConnectionFactory();
 
     private static final ObjectMapper JSON = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false)
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)

--- a/src/main/java/com/codepine/api/testrail/internal/PageDeserializer.java
+++ b/src/main/java/com/codepine/api/testrail/internal/PageDeserializer.java
@@ -41,7 +41,7 @@ public class PageDeserializer extends StdDeserializer<Page> {
         ArrayNode objects = (ArrayNode) node.get(field);
         List list = new ArrayList<>();
         ObjectMapper mapper = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false)
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)

--- a/src/test/java/com/codepine/api/testrail/internal/CaseModuleTest.java
+++ b/src/test/java/com/codepine/api/testrail/internal/CaseModuleTest.java
@@ -29,7 +29,7 @@ import com.codepine.api.testrail.model.CaseField;
 import com.codepine.api.testrail.model.Field;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.Test;
 
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertEquals;
 public class CaseModuleTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
             .registerModules(new CaseModule(), new UnixTimestampModule());
 

--- a/src/test/java/com/codepine/api/testrail/internal/FieldModuleTest.java
+++ b/src/test/java/com/codepine/api/testrail/internal/FieldModuleTest.java
@@ -26,7 +26,7 @@ package com.codepine.api.testrail.internal;
 
 import com.codepine.api.testrail.model.Field;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.Test;
 
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertEquals;
 public class FieldModuleTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
             .registerModules(new FieldModule());
 

--- a/src/test/java/com/codepine/api/testrail/internal/PlanModuleTest.java
+++ b/src/test/java/com/codepine/api/testrail/internal/PlanModuleTest.java
@@ -26,7 +26,7 @@ package com.codepine.api.testrail.internal;
 
 import com.codepine.api.testrail.model.Plan;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.Test;
 
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertEquals;
 public class PlanModuleTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
             .registerModules(new PlanModule(), new UnixTimestampModule());
 

--- a/src/test/java/com/codepine/api/testrail/internal/ResultModuleTest.java
+++ b/src/test/java/com/codepine/api/testrail/internal/ResultModuleTest.java
@@ -30,7 +30,7 @@ import com.codepine.api.testrail.model.Result;
 import com.codepine.api.testrail.model.ResultField;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.Test;
 
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertEquals;
 public class ResultModuleTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
             .registerModules(new ResultModule(), new UnixTimestampModule());
 

--- a/src/test/java/com/codepine/api/testrail/internal/UnixTimestampModuleTest.java
+++ b/src/test/java/com/codepine/api/testrail/internal/UnixTimestampModuleTest.java
@@ -27,7 +27,7 @@ package com.codepine.api.testrail.internal;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.Test;
 
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertEquals;
 public class UnixTimestampModuleTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .setSerializationInclusion(JsonInclude.Include.NON_NULL)
             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
             .registerModules(new UnixTimestampModule());


### PR DESCRIPTION
Replace deprecated PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES with PropertyNamingStrategies.SNAKE_CASE.

This makes it compatible with the latest version of jackson